### PR TITLE
improve: since no instance variable will be used in block, instance_e…

### DIFF
--- a/lib/exception-track.rb
+++ b/lib/exception-track.rb
@@ -18,7 +18,7 @@ module ExceptionTrack
     end
 
     def configure(&block)
-      config.instance_exec(&block)
+      config.instance_eval(&block)
     end
   end
 end


### PR DESCRIPTION
since no instance variable will be used in block, instance_eval is better than instance_exec according to the semantic.