### PR TITLE
update dependency

### DIFF
--- a/exception-track.gemspec
+++ b/exception-track.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "README.md"]
 
-  s.add_dependency "exception_notification", "~> 4"
+  s.add_dependency "exception_notification", ">= 4.1.3"
   s.add_dependency "kaminari", ">= 0.15"
   s.add_dependency "rails", ">= 5.2"
 end


### PR DESCRIPTION
I have encountered an error as
```
/usr/local/bundle/gems/exception-track-1.2.0/lib/exception_notifier/exception_track_notifier.rb:4:in `<module:ExceptionNotifier>': uninitialized constant ExceptionNotifier::BaseNotifier (NameError)
Did you mean?  ExceptionNotifier::SlackNotifier
```
It because of `ExceptionNotifier::ExceptionTrackNotifier` is inherited from `ExceptionNotifier::BaseNotifier`. https://github.com/piecehealth/exception-track/blob/master/lib/exception_notifier/exception_track_notifier.rb#L4

But the `ExceptionNotifier::BaseNotifier` was introduced from `exception_notifier` v.4.1.3, see
* [exception_notifier v.4.1.3](https://github.com/smartinez87/exception_notification/tree/v4.1.3/lib/exception_notifier) There is `ExceptionNotifier::BaseNotifier` in v4.1.3
* [exception_notifier v.4.1.2](https://github.com/smartinez87/exception_notification/tree/v4.1.2/lib/exception_notifier) no `ExceptionNotifier::BaseNotifier`
